### PR TITLE
Recover after interface restart

### DIFF
--- a/canopen_monitor/app.py
+++ b/canopen_monitor/app.py
@@ -2,18 +2,21 @@ from __future__ import annotations
 import curses
 import curses.ascii
 import datetime as dt
-from easygui import fileopenbox
-from shutil import copy
 from enum import Enum
 from . import APP_NAME, \
               APP_VERSION, \
               APP_LICENSE, \
               APP_AUTHOR, \
               APP_DESCRIPTION, \
-              APP_URL, CACHE_DIR
-from .can import MessageTable, MessageType, MagicCANBus
-from .ui import MessagePane, PopupWindow, InputPopup, SelectionPopup, Column
-from .parse import eds
+              APP_URL
+from .can import MessageTable, \
+                 MessageType, \
+                 MagicCANBus
+from .ui import MessagePane, \
+                PopupWindow, \
+                InputPopup, \
+                SelectionPopup, \
+                Column
 from .meta import Meta, FeatureConfig
 
 # Key Constants not defined in curses
@@ -74,7 +77,7 @@ class KeyMap(Enum):
     F1 = {'name': 'F1', 'description': 'Toggle app info menu',
           'key': curses.KEY_F1}
     F2 = {'name': 'F2', 'description': 'Toggle this menu', 'key': curses.KEY_F2}
-    F3 = {'name': 'F3', 'description': 'Toggle eds file select',
+    F3 = {'name': 'F3', 'description': 'DEPRECATED FUNCTION',
           'key': curses.KEY_F3}
     F4 = {'name': 'F4', 'description': 'Toggle add interface',
           'key': curses.KEY_F4}
@@ -339,19 +342,15 @@ class App:
 
     def f3(self):
         """
-        Toggles Add File window
+        DEPRECATED: The use of easygui has proven to add more dependency
+        problems than remove so this function is being dprecated for now
+
+        This function will stay here in order to not break the application
+        input handler
+
         :return: None
         """
-        filepath = fileopenbox(title='Select Object Dictionary Files',
-                               filetypes=[['*.dcf', '*.eds', '*.xdd',
-                                           'Object Dictionary Files']],
-                               multiple=False,
-                               default='~/.cache/canopen-monitor/')
-
-        if (filepath is not None):
-            file = eds.load_eds_file(filepath, self.features.ecss_time)
-            copy(filepath, CACHE_DIR)
-            self.eds_configs[file.node_id] = file
+        pass
 
     def f4(self) -> None:
         """

--- a/canopen_monitor/can/interface.py
+++ b/canopen_monitor/can/interface.py
@@ -137,7 +137,7 @@ class Interface(SocketCanDev):
         """
         if_dev = psutil.net_if_stats().get(self.name)
         if(if_dev is not None):
-            return if_dev.isup and self.age < _STALE_INTERFACE
+            return if_dev.isup
         return False
 
     @property

--- a/canopen_monitor/can/interface.py
+++ b/canopen_monitor/can/interface.py
@@ -33,7 +33,6 @@ class Interface(SocketCanDev):
         self.name = if_name
         self.last_activity = dt.datetime.now()
         self.socket.settimeout(_SOCK_TIMEOUT)
-        self.listening = False
 
     def __enter__(self: Interface) -> Interface:
         """The entry point of an `Interface` in a `with` statement
@@ -90,7 +89,7 @@ class Interface(SocketCanDev):
         """
         super().stop()
         self.socket.close()
-        self.listening = False
+        self.running = False
 
     def restart(self: Interface) -> None:
         """A macro-fuction for restarting the interface connection

--- a/canopen_monitor/can/interface.py
+++ b/canopen_monitor/can/interface.py
@@ -58,8 +58,6 @@ class Interface(SocketCanDev):
     def __exit__(self: Interface, etype, evalue, traceback) -> None:
         """The exit point of an `Interface` in a `with` statement
 
-        This closes the socket previously bound to
-
         :param etype: The type of event
         :type etype: str
 
@@ -83,13 +81,15 @@ class Interface(SocketCanDev):
         """
         while(block_wait and not self.is_up):
             pass
+
+        self.socket = socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW)
         super().start()
-        self.listening = True
 
     def stop(self: Interface) -> None:
         """A wrapper for `pyvit.hw.SocketCanDev.stop()`
         """
         super().stop()
+        self.socket.close()
         self.listening = False
 
     def restart(self: Interface) -> None:

--- a/canopen_monitor/can/interface.py
+++ b/canopen_monitor/can/interface.py
@@ -122,8 +122,6 @@ class Interface(SocketCanDev):
                            interface=self.name,
                            timestamp=dt.datetime.now(),
                            extended=frame.is_extended_id)
-        except OSError:
-            return None
         except socket.timeout:
             return None
 

--- a/canopen_monitor/can/interface.py
+++ b/canopen_monitor/can/interface.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import time
 import psutil
 import socket
 import datetime as dt
@@ -79,9 +80,11 @@ class Interface(SocketCanDev):
         :type block_wait: bool
         """
         while(block_wait and not self.is_up):
-            pass
+            time.sleep(0.01)
 
-        self.socket = socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW)
+        self.socket = socket.socket(socket.PF_CAN,
+                                    socket.SOCK_RAW,
+                                    socket.CAN_RAW)
         super().start()
 
     def stop(self: Interface) -> None:

--- a/canopen_monitor/can/magic_can_bus.py
+++ b/canopen_monitor/can/magic_can_bus.py
@@ -117,12 +117,13 @@ class MagicCANBus:
         :type iface: Interface
         """
 
-        # If the interface is either deleted or goes down,
-        # the handler will try to start it again and read messages as soon as possible
+        # If the interface is either deleted or goes down, the handler will
+        #   try to start it again and read messages as soon as possible
         while (self.keep_alive_list[iface.name].is_set()):
             try:
-                # It is necessary to check `iface.is_up`, so that the handler will not
-                # block on bus reading if the MCB is trying to close all threads and destruct itself
+                # It is necessary to check `iface.is_up`, so that the handler
+                #   will not block on bus reading if the MCB is trying to
+                #   close all threads and destruct itself
                 if iface.is_up:
                     if not iface.running:
                         iface.start()

--- a/canopen_monitor/can/magic_can_bus.py
+++ b/canopen_monitor/can/magic_can_bus.py
@@ -117,23 +117,22 @@ class MagicCANBus:
         :type iface: Interface
         """
 
-        # The outer loop exists to enable interface recovery, if the interface
-        #   is either deleted or goes down, the handler will try to start it
-        #   again and read messages as soon as possible
+        # If the interface is either deleted or goes down,
+        # the handler will try to start it again and read messages as soon as possible
         while (self.keep_alive_list[iface.name].is_set()):
             try:
-                # The inner loop is the constant reading of the bus and loading
-                #   of frames into a thread-safe queue. It is necessary to
-                #   check `iface.is_up` in the inner loop as well, so that the
-                #   handler will not block on bus reading if the MCB is trying
-                #   to close all threads and destruct itself
-                while (iface.is_up and iface.running and
-                       self.keep_alive_list[iface.name].is_set()):
+                # It is necessary to check `iface.is_up`, so that the handler will not
+                # block on bus reading if the MCB is trying to close all threads and destruct itself
+                if iface.is_up:
+                    if not iface.running:
+                        iface.start()
                     frame = iface.recv()
-                    if (frame is not None):
+                    if frame is not None:
                         self.message_queue.put(frame, block=True)
-                iface.restart()
+                else:
+                    iface.stop()
             except OSError:
+                iface.stop()
                 pass
         iface.stop()
 

--- a/scripts/interface-status.py
+++ b/scripts/interface-status.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import argparse
+import datetime
+import time
+import psutil
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='interface-status',
+                                     description='Simple script to display'
+                                                 ' current status of a'
+                                                 ' device interface',
+                                     allow_abbrev=False)
+    parser.add_argument('-i', '--interface',
+                        dest='interface',
+                        type=str,
+                        nargs='?',
+                        default='vcan0',
+                        help='The interface whose status is to be displayed.')
+
+    parser.add_argument('-d', '--delay',
+                        type=int,
+                        default=1,
+                        help='Adjust the status update delay time')
+
+    args = parser.parse_args()
+
+    while True:
+        interface = psutil.net_if_stats().get(args.interface)
+        exists = "EXISTS" if interface is not None else "DOES NOT EXIST"
+        status = "IS UP" if (interface is not None and interface.isup) else "IS NOT UP"
+        print("Interface " + args.interface + " " + exists + " and " + status + " | " + str(datetime.datetime.now()))
+        time.sleep(args.delay)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/issue76_demo.py
+++ b/scripts/issue76_demo.py
@@ -1,0 +1,56 @@
+import subprocess
+import socket
+import struct
+import can
+import random
+
+_FRAME_FORMAT = "=IB3xBBBBBBBB"
+_FRAME_SIZE = struct.calcsize(_FRAME_FORMAT)
+_RANDOM_MESSAGE = can.Message(arbitration_id=random.randint(0x0, 0x7ff),
+                          data=[random.randint(0, 255) for _ in range(8)],
+                          is_extended_id=False)
+
+def interface_activity(cansocket):
+
+    frames_received = 0
+    errno19_count = 0
+    timeouts = 0
+
+    # create the device interface using index 11 and verify that the interface was created
+    subprocess.call(['sudo', 'ip', 'link', 'add', 'index', '11', 'dev', 'vcan0', 'type', 'vcan'])
+    subprocess.call(['sudo', 'ip', 'link', 'set', 'vcan0', 'up'])
+    assert(subprocess.check_output(['ip', 'link', 'show']).decode('utf-8').find('11: vcan0') != -1)
+
+    # create bus for sending messages and bind the socket to the channel
+    bus = can.interface.Bus(channel='vcan0', bustype='socketcan')
+    cansocket.bind(('vcan0',))
+
+    # send a message and try to receive it
+    for i in range(10):
+        bus.send(_RANDOM_MESSAGE)
+        try:
+            frame = cansocket.recv(_FRAME_SIZE)
+            if frame is not None:
+                frames_received += 1
+        except socket.timeout:
+            timeouts += 1
+        except OSError as err:
+            if err.errno == 19:
+                errno19_count += 1
+
+    print("Frames received: " + str(frames_received))
+    print("No such device errors: " + str(errno19_count))
+    print("Number of timeouts: " + str(timeouts))
+
+    # Remove the device interface and verify that it's been deleted
+    subprocess.call(['sudo', 'ip', 'link', 'del', 'dev', 'vcan0'])
+    assert (subprocess.check_output(['ip', 'link', 'show']).decode('utf-8').find('vcan0') == -1)
+
+
+test_cansocket = socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW)
+test_cansocket.settimeout(0.1)
+
+print("\nFIRST TIME (WORKING)\n")
+interface_activity(test_cansocket)
+print("\nSECOND TIME (BROKEN)\n")
+interface_activity(test_cansocket)

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,7 @@ setuptools.setup(
     install_requires=[
         "pyvit >= 0.2.1",
         "psutil >= 5.8.0",
-        "python-dateutil >= 2.8.1",
-        "easygui >= 0.98.2",
+        "python-dateutil >= 2.8.1"
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Addresses issue #76. The `handler` method in `magic_can_bus.py` now stops and starts its `Interface` instance, and an `Interface` now closes its socket and creates a new socket when it stops and starts respectively