### PR TITLE
DCF parse fix

### DIFF
--- a/canopen_monitor/parse/canopen.py
+++ b/canopen_monitor/parse/canopen.py
@@ -18,7 +18,7 @@ class CANOpenParser:
         self.eds_configs = eds_configs
 
     def get_name(self, message: Message) -> Union[str, None]:
-        node_id = str(hex(message.node_id))
+        node_id = hex(message.node_id)
         parser = self.eds_configs.get(node_id)
         return parser.device_commissioning.node_name \
             if parser else hex(message.node_id)
@@ -36,7 +36,7 @@ class CANOpenParser:
         `str`: The parsed message
 
         """
-        node_id = str(hex(message.node_id))
+        node_id = hex(message.node_id)
         eds_config = self.eds_configs.get(node_id) \
             if node_id is not None else None
 

--- a/canopen_monitor/parse/canopen.py
+++ b/canopen_monitor/parse/canopen.py
@@ -20,8 +20,14 @@ class CANOpenParser:
     def get_name(self, message: Message) -> Union[str, None]:
         node_id = hex(message.node_id)
         parser = self.eds_configs.get(node_id)
-        return parser.device_commissioning.node_name \
-            if parser else hex(message.node_id)
+        if hasattr(parser, 'device_comissioning'):
+            if parser.device_comissioning is not None:
+                return parser.device_comissioning.node_name \
+                    if parser else hex(message.node_id)
+        if hasattr(parser, 'device_commissioning'):
+            if parser.device_commissioning is not None:
+                return parser.device_commissioning.node_name \
+                    if parser else hex(message.node_id)
 
     def parse(self, message: Message) -> (str, str):
         """

--- a/canopen_monitor/parse/canopen.py
+++ b/canopen_monitor/parse/canopen.py
@@ -18,8 +18,8 @@ class CANOpenParser:
         self.eds_configs = eds_configs
 
     def get_name(self, message: Message) -> Union[str, None]:
-        # import ipdb; ipdb.set_trace()
-        parser = self.eds_configs.get(message.node_id)
+        node_id = str(hex(message.node_id))
+        parser = self.eds_configs.get(node_id)
         return parser.device_commissioning.node_name \
             if parser else hex(message.node_id)
 
@@ -36,7 +36,7 @@ class CANOpenParser:
         `str`: The parsed message
 
         """
-        node_id = message.node_id
+        node_id = str(hex(message.node_id))
         eds_config = self.eds_configs.get(node_id) \
             if node_id is not None else None
 

--- a/canopen_monitor/parse/eds.py
+++ b/canopen_monitor/parse/eds.py
@@ -109,8 +109,8 @@ class Metadata:
     def __init__(self, data):
         # Process all sub-data
         for e in data:
-            # Skip comment lines
-            if (e[0] == ';'):
+            # Skip comment lines and indices
+            if (e[0] == ';' or e[0] == '['):
                 continue
 
             # Separate field name from field value
@@ -148,8 +148,8 @@ class Index:
 
         # Process all sub-data
         for e in data:
-            # Skip commented lines
-            if (e[0] == ';'):
+            # Skip commented lines and indices
+            if (e[0] == ';' or e[0] == '['):
                 continue
 
             # Separate field name from field value
@@ -300,7 +300,11 @@ class EDS(OD):
                     continue
 
                 section = eds_data[prev:i]
-                id = section[0][1:-1].split('sub')
+
+                # Get the sub split id inside the square brackets
+                id = ''
+                for v in section:
+                    if v[0] == '[': id = v[1:-1].split('sub')
 
                 if all(c in string.hexdigits for c in id[0]):
                     index = hex(int(id[0], 16))
@@ -317,7 +321,7 @@ class EDS(OD):
                 prev = i + 1
 
         if self.device_commissioning is not None:
-            self.node_id = convert_value(self.device_commissioning.node_id)
+            self.node_id = convert_value(self.device_commissioning.node_n_id)
         elif '0x2101' in self.indices.keys():
             self.node_id = self['0x2101'].default_value
         else:

--- a/canopen_monitor/parse/eds.py
+++ b/canopen_monitor/parse/eds.py
@@ -322,6 +322,8 @@ class EDS(OD):
 
         if self.device_commissioning is not None:
             self.node_id = convert_value(self.device_commissioning.node_n_id)
+        elif self.device_comissioning is not None:
+            self.node_id = convert_value(self.device_comissioning.node_n_id)
         elif '0x2101' in self.indices.keys():
             self.node_id = self['0x2101'].default_value
         else:

--- a/canopen_monitor/parse/pdo.py
+++ b/canopen_monitor/parse/pdo.py
@@ -108,7 +108,7 @@ def parse_pdo(num_elements, pdo_type, cob_id, eds, data):
                                         f"Unable to find eds data for pdo type"
                                         f" {hex(pdo_type)} index {i}")
 
-        pdo_definition = int(eds_record.default_value, 16).to_bytes(4, "big")
+        pdo_definition = int(eds_record.default_value).to_bytes(4, "big")
 
         index = pdo_definition[0:3]
         size = pdo_definition[3]
@@ -128,8 +128,8 @@ def parse_pdo(num_elements, pdo_type, cob_id, eds, data):
         masked_data = int.from_bytes(data[start:end], "big") & mask
         masked_data = masked_data >> data_start % 8
         masked_data = masked_data.to_bytes(num_bytes, "big")
-        output_string = f"{eds_details[1]} -" \
-                        f" {decode(eds_details[0], masked_data)}" + \
+        output_string = f"{eds_details[1]}: " \
+                        f"{decode(eds_details[0], masked_data)}," + \
                         output_string
         if i > 1:
             output_string = " " + output_string


### PR DESCRIPTION
This fix is primarily fixing a bug where a new DCF file generated for Oresat 0.5 will not parse properly and crash on startup. The PR addresses issue #86 and should be good to close afterwards.

Something to note, the bug in issue #87 is also causing CM to crash, so as a temporary fix, you will need to change every location where it says `[DeviceComissioning]` to `[DeviceCommissioning]` (adding an 'm') in your DCF. When I continue development, I'll use this current branch to fix issue #87 as well.